### PR TITLE
GH-2: Add /health endpoint that returns server status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build test lint
+
+build:
+	@echo "Build successful (no compilation needed for Node.js)"
+
+test:
+	node src/server.test.js
+
+lint:
+	@node -c src/server.js
+	@node -c src/server.test.js
+	@echo "Lint passed"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "engineering-excellence",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node src/server.test.js"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,26 @@
+const http = require("http");
+
+const PORT = process.env.PORT || 3000;
+
+function handleHealth(req, res) {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }));
+}
+
+function requestHandler(req, res) {
+  if (req.method === "GET" && req.url === "/health") {
+    return handleHealth(req, res);
+  }
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Not Found" }));
+}
+
+const server = http.createServer(requestHandler);
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = { requestHandler };

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -1,0 +1,43 @@
+const http = require("http");
+const assert = require("assert");
+const { requestHandler } = require("./server");
+
+const server = http.createServer(requestHandler);
+
+function request(path) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${server.address().port}${path}`, (res) => {
+      let body = "";
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => resolve({ statusCode: res.statusCode, body: JSON.parse(body) }));
+    });
+    req.on("error", reject);
+  });
+}
+
+async function runTests() {
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  try {
+    // Test: GET /health returns 200 with status and timestamp
+    const res = await request("/health");
+    assert.strictEqual(res.statusCode, 200, "Expected HTTP 200");
+    assert.strictEqual(res.body.status, "ok", 'Expected status "ok"');
+    assert.ok(res.body.timestamp, "Expected timestamp field");
+    // Verify timestamp is valid ISO8601
+    assert.ok(!isNaN(Date.parse(res.body.timestamp)), "Expected valid ISO8601 timestamp");
+
+    // Test: Unknown route returns 404
+    const notFound = await request("/unknown");
+    assert.strictEqual(notFound.statusCode, 404, "Expected HTTP 404 for unknown route");
+
+    console.log("All tests passed");
+  } finally {
+    server.close();
+  }
+}
+
+runTests().catch((err) => {
+  console.error("Test failed:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2.

Closes #2

## Changes

GitHub Issue #2: Add /health endpoint that returns server status

## Description
Create a `/health` endpoint that returns the current server status.

## Acceptance Criteria
- GET `/health` returns JSON `{"status": "ok", "timestamp": "<ISO8601>"}`
- Returns HTTP 200
- Include a basic unit test

## Tech
- Simple HTTP handler (any framework or stdlib)
- Add to `src/` directory